### PR TITLE
renegade-dealer: Add authorization check via request signature

### DIFF
--- a/renegade-dealer-api/Cargo.toml
+++ b/renegade-dealer-api/Cargo.toml
@@ -6,6 +6,12 @@ edition = "2021"
 [dependencies]
 ark-bn254 = "0.4.0"
 ark-mpc = { git = "https://github.com/renegade-fi/ark-mpc.git" }
+
+k256 = "0.13"
+
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = "1.8"
+
+[dev-dependencies]
+rand = "0.8"

--- a/renegade-dealer-api/src/lib.rs
+++ b/renegade-dealer-api/src/lib.rs
@@ -9,7 +9,39 @@
 #![feature(generic_const_exprs)]
 #![feature(inherent_associated_types)]
 
+use k256::PublicKey;
 use serde::{Deserialize, Serialize};
+
+/// Serialize a public key
+use serde::{de::Error as DeError, Deserializer, Serializer};
+
+/// Custom serialization for `PublicKey`
+fn serialize_key<S>(key: &PublicKey, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let bytes = key.to_sec1_bytes().to_vec();
+    serializer.serialize_bytes(&bytes)
+}
+
+/// Custom deserialization for `PublicKey`
+fn deserialize_key<'de, D>(deserializer: D) -> Result<PublicKey, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let bytes = <Vec<u8>>::deserialize(deserializer)?;
+    PublicKey::from_sec1_bytes(&bytes)
+        .map_err(|e| DeError::custom(format!("Invalid public key bytes: {}", e)))
+}
+
+// -------------
+// | Api Types |
+// -------------
+
+/// The header name for the party ID
+pub const PARTY_ID_HEADER: &str = "X-Party-Id";
+/// The header name for the signature
+pub const SIGNATURE_HEADER: &str = "X-Signature";
 
 /// A type alias for the request
 pub type RequestId = uuid::Uuid;
@@ -33,6 +65,13 @@ pub struct ErrorResponse {
 /// A request for offline phase randomness from the dealer
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct DealerRequest {
+    /// The public key of the first party in the exchange
+    #[serde(serialize_with = "serialize_key", deserialize_with = "deserialize_key")]
+    pub first_party_key: PublicKey,
+    /// The public key of the second party in the exchange
+    #[serde(serialize_with = "serialize_key", deserialize_with = "deserialize_key")]
+    pub second_party_key: PublicKey,
+
     /// The number of random bits to generate
     #[serde(default)]
     pub n_random_bits: u32,
@@ -54,6 +93,19 @@ pub struct DealerRequest {
 }
 
 impl DealerRequest {
+    /// Create a new request from a pair of keys
+    pub fn new(first_party_key: PublicKey, second_party_key: PublicKey) -> Self {
+        Self {
+            first_party_key,
+            second_party_key,
+            n_random_bits: 0,
+            n_random_values: 0,
+            n_input_masks: 0,
+            n_inverse_pairs: 0,
+            n_triples: 0,
+        }
+    }
+
     /// Return the total number of requested values
     pub fn total_values(&self) -> u32 {
         self.n_random_bits
@@ -61,6 +113,36 @@ impl DealerRequest {
             + self.n_input_masks
             + self.n_inverse_pairs
             + self.n_triples
+    }
+
+    /// Set the number of random bits to generate
+    pub fn with_n_random_bits(mut self, n_random_bits: u32) -> Self {
+        self.n_random_bits = n_random_bits;
+        self
+    }
+
+    /// Set the number of shared random values to generate
+    pub fn with_n_random_values(mut self, n_random_values: u32) -> Self {
+        self.n_random_values = n_random_values;
+        self
+    }
+
+    /// Set the number of input masks to generate
+    pub fn with_n_input_masks(mut self, n_input_masks: u32) -> Self {
+        self.n_input_masks = n_input_masks;
+        self
+    }
+
+    /// Set the number of inverse pairs to generate
+    pub fn with_n_inverse_pairs(mut self, n_inverse_pairs: u32) -> Self {
+        self.n_inverse_pairs = n_inverse_pairs;
+        self
+    }
+
+    /// Set the number of Beaver triples to generate
+    pub fn with_n_triples(mut self, n_triples: u32) -> Self {
+        self.n_triples = n_triples;
+        self
     }
 }
 
@@ -120,5 +202,30 @@ impl DealerResponse {
         assert_eq!(n, c.len());
 
         self.beaver_triples = (a, b, c);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use k256::SecretKey;
+    use rand::thread_rng;
+
+    use crate::DealerRequest;
+
+    /// Test serialization + deserialization of the `DealerRequest`
+    #[test]
+    fn test_req_serialization() {
+        let mut rng = thread_rng();
+        let key1 = SecretKey::random(&mut rng);
+        let key2 = SecretKey::random(&mut rng);
+
+        let req = DealerRequest::new(key1.public_key(), key2.public_key())
+            .with_n_triples(100)
+            .with_n_input_masks(10);
+
+        let ser = serde_json::to_vec(&req).unwrap();
+        let de: DealerRequest = serde_json::from_slice(&ser).unwrap();
+
+        assert_eq!(req, de);
     }
 }

--- a/renegade-dealer/Cargo.toml
+++ b/renegade-dealer/Cargo.toml
@@ -12,10 +12,16 @@ renegade-dealer-api = { path = "../renegade-dealer-api" }
 # === Cryptography === #
 ark-bn254 = "0.4"
 ark-mpc = { git = "https://github.com/renegade-fi/ark-mpc.git" }
+k256 = "0.13"
 
 # === Misc === #
+base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
 itertools = "0.12"
 rand = "0.8"
+serde_json = "1.0"
 tokio = { version = "1.21", features = ["full"] }
 uuid = { version = "1.8", features = ["v4"] }
+
+[dev-dependencies]
+k256 = "0.13"

--- a/renegade-dealer/src/main.rs
+++ b/renegade-dealer/src/main.rs
@@ -18,20 +18,32 @@
 
 mod dealer;
 
+use ark_mpc::PARTY0;
+use ark_mpc::{network::PartyId, PARTY1};
+use base64::prelude::*;
 use clap::Parser;
 use dealer::{
     create_dealer_sender_receiver, create_response_sender_receiver, Dealer, DealerJob, DealerSender,
 };
-use renegade_dealer_api::{DealerRequest, DealerResponse, ErrorResponse, RequestId};
+use k256::ecdsa::{signature::Verifier, Signature, VerifyingKey};
+use renegade_dealer_api::{
+    DealerRequest, DealerResponse, ErrorResponse, RequestId, PARTY_ID_HEADER, SIGNATURE_HEADER,
+};
+use uuid::Uuid;
 use warp::Filter;
 
 /// The maximum number of values that may be requested at once by a pair
 const MAX_REQUEST_SIZE: u32 = 1_500_000;
 
 /// An error type indicating a bad request
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct BadRequestError(&'static str);
 impl warp::reject::Reject for BadRequestError {}
+
+/// An error type indicating the request is not authorized
+#[derive(Debug)]
+struct UnauthorizedError(&'static str);
+impl warp::reject::Reject for UnauthorizedError {}
 
 /// Renegade Dealer server configuration
 #[derive(Parser, Debug)]
@@ -56,36 +68,66 @@ async fn main() {
         .and(warp::path("v0"))
         .and(warp::path("offline-phase"))
         .and(warp::path::param::<RequestId>())
+        .and(warp::header::header::<PartyId>(PARTY_ID_HEADER))
+        .and(warp::header::header::<String>(SIGNATURE_HEADER))
         .and(warp::body::json::<DealerRequest>())
-        .and_then(move |request_id, body| {
+        .and_then(move |request_id, party_id, sig, body| {
             let dealer_send = dealer_send.clone();
             async move {
-                match handle_req(request_id, body, dealer_send).await {
+                match handle_req(request_id, party_id, sig, body, dealer_send).await {
                     Ok(resp) => Ok(warp::reply::json(&resp)),
                     Err(rej) => Err(rej),
                 }
             }
-        });
+        })
+        .recover(handle_rejection);
 
-    let routes = setup.recover(handle_rejection);
+    warp::serve(setup).run(([127, 0, 0, 1], cli.port)).await
+}
 
-    warp::serve(routes).run(([127, 0, 0, 1], cli.port)).await
+/// Validates the incoming request headers and body.
+fn validate_request(
+    request_id: Uuid,
+    party_id: PartyId,
+    signature: &str,
+    body: &DealerRequest,
+) -> Result<(), warp::Rejection> {
+    // Sizing constraints
+    if body.total_values() > MAX_REQUEST_SIZE {
+        return Err(warp::reject::custom(BadRequestError("Request size too large")));
+    }
+
+    // Party ID validation
+    if !(party_id == PARTY0 || party_id == PARTY1) {
+        return Err(warp::reject::custom(BadRequestError("Invalid party ID")));
+    }
+
+    // Verify the signature
+    let key: VerifyingKey =
+        if party_id == PARTY0 { body.first_party_key } else { body.second_party_key }.into();
+    let decoded = BASE64_STANDARD.decode(signature.as_bytes()).unwrap();
+    let sig = Signature::from_slice(&decoded).unwrap();
+
+    let body_bytes = serde_json::to_vec(&body).unwrap();
+    let payload = [request_id.to_bytes_le().as_ref(), &body_bytes].concat();
+    key.verify(&payload, &sig).map_err(|_| UnauthorizedError("Invalid signature"))?;
+
+    Ok(())
 }
 
 /// Handle an incoming client request
 async fn handle_req(
     request_id: RequestId,
+    party_id: PartyId,
+    signature: String,
     body: DealerRequest,
     dealer_queue: DealerSender,
 ) -> Result<DealerResponse, warp::Rejection> {
-    if body.total_values() > MAX_REQUEST_SIZE {
-        return Err(warp::reject::custom(BadRequestError("Request size too large")));
-    }
-
+    validate_request(request_id, party_id, &signature, &body)?;
     let (send, mut recv) = create_response_sender_receiver();
-    dealer_queue.send(DealerJob::new(request_id, body, send)).unwrap();
+    dealer_queue.send(DealerJob::new(request_id, party_id, body, send)).unwrap();
 
-    Ok(recv.recv().await.unwrap())
+    recv.recv().await.unwrap().map_err(warp::reject::custom)
 }
 
 /// Handle a rejection from the dealer
@@ -93,6 +135,9 @@ async fn handle_rejection(err: warp::Rejection) -> Result<impl warp::Reply, warp
     if let Some(BadRequestError(msg)) = err.find::<BadRequestError>() {
         let json = warp::reply::json(&ErrorResponse { message: msg, code: 400 });
         Ok(warp::reply::with_status(json, warp::http::StatusCode::BAD_REQUEST))
+    } else if let Some(UnauthorizedError(msg)) = err.find::<UnauthorizedError>() {
+        let json = warp::reply::json(&ErrorResponse { message: msg, code: 401 });
+        Ok(warp::reply::with_status(json, warp::http::StatusCode::UNAUTHORIZED))
     } else {
         Err(err)
     }


### PR DESCRIPTION
### Purpose
This PR adds an authentication check to the dealer. It requires that both parties submit signatures using an ephemeral key and that both parties submit the request with the same public keys -- thereby authenticating the request.

### Testing
- Unit tests pass
- Wrote a simple client with auth, verified auth works correctly