### PR TITLE
renegade-dealer: Add healthcheck endpoint and deployment setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM --platform=arm64 rust:latest AS chef
+
+WORKDIR /build
+COPY ./rust-toolchain ./rust-toolchain
+RUN rustup install $(cat rust-toolchain)
+
+RUN apt-get update && apt-get install -y libssl-dev
+
+# Install chef and generate a recipe
+RUN cargo install cargo-chef
+
+COPY ./Cargo.toml ./Cargo.toml
+COPY ./Cargo.lock ./Cargo.lock
+COPY ./renegade-dealer ./renegade-dealer
+COPY ./renegade-dealer-api ./renegade-dealer-api
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Disable compiler warnings and enable backtraces for panic
+ENV RUSTFLAGS=-Awarnings
+ENV RUST_BACKTRACE=1
+
+# Build only the dependencies to cache them in this layer
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Copy back in the full sources and build the tests
+WORKDIR /build
+COPY ./Cargo.lock ./Cargo.lock
+COPY ./renegade-dealer ./renegade-dealer
+COPY ./renegade-dealer-api ./renegade-dealer-api
+
+WORKDIR /build/renegade-dealer
+RUN cargo build --release --quiet --all-features
+
+ENTRYPOINT ["cargo", "run", "--release", "--all-features"]
+

--- a/build_and_push.sh
+++ b/build_and_push.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+REGION=ca-central-1
+ENVIRONMENT=${1:-staging}
+ECR_URL=377928551571.dkr.ecr.ca-central-1.amazonaws.com/renegade-dealer-$ENVIRONMENT
+
+docker build -t dealer:latest .
+aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ECR_URL
+
+docker tag dealer:latest $ECR_URL:latest
+docker push $ECR_URL:latest

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+REGION=ca-central-1
+ENVIRONMENT=${1:-staging}
+CLUSTER_NAME=$ENVIRONMENT-renegade-dealer-cluster
+SERVICE_NAME=$ENVIRONMENT-renegade-dealer-service
+
+# Update the ECS service to use the latest image
+aws ecs update-service --region $REGION --cluster $CLUSTER_NAME --service $SERVICE_NAME --force-new-deployment

--- a/renegade-dealer/src/main.rs
+++ b/renegade-dealer/src/main.rs
@@ -64,7 +64,7 @@ async fn main() {
     Dealer::start(dealer_recv);
 
     // POST /v0/offline-phase/:request_id
-    let setup = warp::post()
+    let offline_phase = warp::post()
         .and(warp::path("v0"))
         .and(warp::path("offline-phase"))
         .and(warp::path::param::<RequestId>())
@@ -82,7 +82,13 @@ async fn main() {
         })
         .recover(handle_rejection);
 
-    warp::serve(setup).run(([127, 0, 0, 1], cli.port)).await
+    // GET /ping
+    let ping = warp::get()
+        .and(warp::path("ping"))
+        .map(|| warp::reply::with_status("PONG", warp::http::StatusCode::OK));
+
+    let routes = offline_phase.or(ping);
+    warp::serve(routes).run(([0, 0, 0, 0], cli.port)).await
 }
 
 /// Validates the incoming request headers and body.


### PR DESCRIPTION
### Purpose
This PR sets up the deployment information needed for the `renegade-dealer`. This includes a Dockerfile to build an image and scripts to build and push to the ECR repository that the ECS definition expects.

### Testing
- Deployed the dealer to our staging env, verified its functionality