### PR TITLE
renegade-dealer, renegade-dealer-api: Add optional `mac_key` to request

### DIFF
--- a/renegade-dealer/src/dealer.rs
+++ b/renegade-dealer/src/dealer.rs
@@ -137,9 +137,9 @@ impl Dealer {
         let req = &req1.request;
 
         // Generate the mac key
-        let mac_key = Scalar::random(&mut rng);
-        let mac_share1 = Scalar::random(&mut rng);
-        let mac_share2 = mac_key - mac_share1;
+        let mac_share1 = req1.request.mac_key.unwrap_or_else(|| Scalar::random(&mut rng));
+        let mac_share2 = req2.request.mac_key.unwrap_or_else(|| Scalar::random(&mut rng));
+        let mac_key = mac_share1 + mac_share2;
 
         let mut resp1 = DealerResponse { mac_key_share: mac_share1, ..Default::default() };
         let mut resp2 = DealerResponse { mac_key_share: mac_share2, ..Default::default() };


### PR DESCRIPTION
### Purpose
This PR allows clients to specify the MAC key share to use for their half of the request. If none is specified, a key will be generated by the dealer and sent with the response.

### Testing
- Unit tests pass
- Tested locally, verified the keys were the same